### PR TITLE
Exclude tests from installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/2Fake/devolo_home_control_api",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=("tests*",)),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
## Proposed change

Installing tests is not generally desirable in the first place, but particularly not in the global top level `tests` package.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply. 
-->

- [ ] Version number in \_\_init\_\_.py was properly set.
- [ ] Changelog is updated.
