### PR TITLE
Readd old websocket-client support

### DIFF
--- a/devolo_home_control_api/backend/mprm_rest.py
+++ b/devolo_home_control_api/backend/mprm_rest.py
@@ -4,7 +4,7 @@ import sys
 from abc import ABC
 
 from requests import Session
-from requests.exceptions import ConnectionError, ReadTimeout
+from requests.exceptions import ConnectionError, ReadTimeout  # pylint: disable=redefined-builtin
 
 from ..devices.gateway import Gateway
 from ..exceptions.gateway import GatewayOfflineError

--- a/devolo_home_control_api/backend/mprm_websocket.py
+++ b/devolo_home_control_api/backend/mprm_websocket.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 
 import requests
 import websocket
-from packaging import version
+from pkg_resources import parse_version
 from urllib3.connection import ConnectTimeoutError
 
 from ..exceptions.gateway import GatewayOfflineError
@@ -77,8 +77,9 @@ class MprmWebsocket(MprmRest, ABC):
                  f"com/prosyst/mbs/services/fim/FunctionalItemEvent/UNREGISTERED" \
                  f"&filter=(|(GW_ID={self.gateway.id})(!(GW_ID=*)))"
         self._logger.debug("Connecting to %s", ws_url)
-        if version.parse(websocket.__version__) < version.parse("0.58.0"):  # Just in case we hit an outdated version
-            self._logger.debug("Please consider updating your websocket-client version.")
+        if parse_version(websocket.__version__) < parse_version("0.58.0"):  # Just in case we hit an outdated version
+            self._logger.warning(
+                "Please consider updating your websocket-client version. Support for <0.58.0 will be removed soon.")
             self._ws = websocket.WebSocketApp(ws_url,
                                               cookie=cookie,
                                               on_open=self._on_open_old,

--- a/devolo_home_control_api/backend/mprm_websocket.py
+++ b/devolo_home_control_api/backend/mprm_websocket.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 
 import requests
 import websocket
+from packaging import version
 from urllib3.connection import ConnectTimeoutError
 
 from ..exceptions.gateway import GatewayOfflineError
@@ -76,13 +77,23 @@ class MprmWebsocket(MprmRest, ABC):
                  f"com/prosyst/mbs/services/fim/FunctionalItemEvent/UNREGISTERED" \
                  f"&filter=(|(GW_ID={self.gateway.id})(!(GW_ID=*)))"
         self._logger.debug("Connecting to %s", ws_url)
-        self._ws = websocket.WebSocketApp(ws_url,
-                                          cookie=cookie,
-                                          on_open=self._on_open,
-                                          on_message=self._on_message,
-                                          on_error=self._on_error,
-                                          on_close=self._on_close,
-                                          on_pong=self._on_pong)
+        if version.parse(websocket.__version__) < version.parse("0.58.0"):  # Just in case we hit an outdated version
+            self._logger.debug("Please consider updating your websocket-client version.")
+            self._ws = websocket.WebSocketApp(ws_url,
+                                              cookie=cookie,
+                                              on_open=self._on_open_old,
+                                              on_message=self._on_message_old,
+                                              on_error=self._on_error_old,
+                                              on_close=self._on_close_old,
+                                              on_pong=self._on_pong_old)
+        else:
+            self._ws = websocket.WebSocketApp(ws_url,
+                                              cookie=cookie,
+                                              on_open=self._on_open,
+                                              on_message=self._on_message,
+                                              on_error=self._on_error,
+                                              on_close=self._on_close,
+                                              on_pong=self._on_pong)
         self._ws.run_forever(ping_interval=30, ping_timeout=5)
 
     def websocket_disconnect(self, event: str = ""):
@@ -96,7 +107,11 @@ class MprmWebsocket(MprmRest, ABC):
 
     def _on_close(self, ws: websocket.WebSocketApp):  # pylint: disable=unused-argument
         """ Callback method to react on closing the websocket. """
-        self._logger.info("Closed web socket connection.")
+        self._logger.info("Closed websocket connection.")
+
+    def _on_close_old(self):
+        """ Deprecated callback method to react on closing the websocket. """
+        self._on_close(ws=self._ws)
 
     def _on_error(self, ws: websocket.WebSocketApp, error: Exception):
         """ Callback method to react on errors. We will try reconnecting with prolonging intervals. """
@@ -112,6 +127,10 @@ class MprmWebsocket(MprmRest, ABC):
             sleep_interval = sleep_interval * 2 if sleep_interval < 2048 else 3600
 
         self.websocket_connect()
+
+    def _on_error_old(self, error: Exception):
+        """ Deprecated callback method to react on errors. """
+        self._on_error(ws=self._ws, error=error)
 
     def _on_message(self, ws: websocket.WebSocketApp, message: str):  # pylint: disable=unused-argument
         """ Callback method to react on a message. """
@@ -131,6 +150,10 @@ class MprmWebsocket(MprmRest, ABC):
 
         self.on_update(msg)
 
+    def _on_message_old(self, message: str):
+        """ Deprecated callback method to react on a message. """
+        self._on_message(ws=self._ws, message=message)
+
     def _on_open(self, ws: websocket.WebSocketApp):
         """ Callback method to keep the websocket open. """
 
@@ -142,9 +165,17 @@ class MprmWebsocket(MprmRest, ABC):
         threading.Thread(target=run, name=f"{self.__class__.__name__}.websocket_run").start()
         self._connected = True
 
+    def _on_open_old(self):
+        """ Deprecated callback method to keep the websocket open. """
+        self._on_open(ws=self._ws)
+
     def _on_pong(self, ws: websocket.WebSocketApp, *args):  # pylint: disable=unused-argument
         """ Callback method to keep the session valid. """
         self.refresh_session()
+
+    def _on_pong_old(self, *args):
+        """ Deprecated callback method to keep the session valid. """
+        self._on_pong(ws=self._ws, *args)
 
     def _try_reconnect(self, sleep_interval: int):
         """ Try to reconnect to the websocket. """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.17.2] - 2021/04/09
+
+### Added
+
+- Restored support for older websocket_client versions although not recommended to still use them
+
 ## [v0.17.1] - 2021/03/25
 
 ### Fixed


### PR DESCRIPTION
## Proposed change

<!--
  Please give us the big picture of your change.
-->
Just supporting the new websocket-client version causes trouble, so we need to support both for a while.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [x] Changelog is updated.
