### PR TITLE
Ignore pending operation messages of HTTP devices

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: "3.6"
+        python-version: "3.8"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/devolo_home_control_api/publisher/updater.py
+++ b/devolo_home_control_api/publisher/updater.py
@@ -118,10 +118,13 @@ class Updater:
         element_uid = message['properties']['uid']
 
         # Early return on useless messages
-        if element_uid in [
-                "devolo.PairDevice",
-                "devolo.RemoveDevice",
-                "devolo.mprm.gw.GatewayManager",
+        if [
+                uid
+                for uid in ["devolo.HttpRequest",
+                            "devolo.PairDevice",
+                            "devolo.RemoveDevice",
+                            "devolo.mprm.gw.GatewayManager"]
+                if (uid in element_uid)
         ]:
             return
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Drop Support for Python 3.6
+
+### Fixed
+
+- Ignore pending operation messages of HTTP devices
+
 ## [0.17.4] - 2021/07/01
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,5 @@ setup(
         ],
     },
     cmdclass={"develop": PostDevelopCommand},
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -446,10 +446,11 @@ class TestUpdater:
 
     def test__pending_operations_useless(self, mocker):
         spy = mocker.spy(self.homecontrol.updater._publisher, 'dispatch')
-        self.homecontrol.updater._pending_operations(message={"properties": {
-            "uid": "devolo.PairDevice",
-        }})
-        spy.assert_not_called()
+        for uid in ["devolo.HttpRequest", "devolo.PairDevice", "devolo.RemoveDevice", "devolo.mprm.gw.GatewayManager"]:
+            self.homecontrol.updater._pending_operations(message={"properties": {
+                "uid": uid,
+            }})
+            spy.assert_not_called()
 
     def test__protection_local(self):
         device = self.devices['mains']


### PR DESCRIPTION
## Proposed change
Firing an HTTP device led to a KeyError when handling its pending operation. We have to drop support for Python 3.6, as our dependencies don't support it any longer.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [x] Changelog is updated.
