### PR TITLE
Handle unreliable session refreshs more graceful

### DIFF
--- a/devolo_home_control_api/homecontrol.py
+++ b/devolo_home_control_api/homecontrol.py
@@ -3,6 +3,8 @@ import threading
 from typing import Any, Dict, List, Optional
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
 from zeroconf import Zeroconf
 
 from . import __version__
@@ -41,9 +43,13 @@ class HomeControl(Mprm):
     """
 
     def __init__(self, gateway_id: str, mydevolo_instance: Mydevolo, zeroconf_instance: Optional[Zeroconf] = None) -> None:
+        retry = Retry(total=5, backoff_factor=0.1, allowed_methods=("GET", "POST"))
+        adapter = HTTPAdapter(max_retries=retry)
+
         self._mydevolo = mydevolo_instance
         self._session = requests.Session()
         self._session.headers.update({"User-Agent": f"devolo_home_control_api/{__version__}"})
+        self._session.mount("http://", adapter)
         self._zeroconf = zeroconf_instance
         self.gateway = Gateway(gateway_id, mydevolo_instance)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.18.2] - 2022/05/06
+
+### Fixed
+
+- Handle unreliable session refreshs more graceful
+
 ## [v0.18.1] - 2022/04/11
 
 ### Fixed

--- a/tests/test_mprm_websocket.py
+++ b/tests/test_mprm_websocket.py
@@ -1,4 +1,5 @@
 import time
+from unittest.mock import patch
 
 import pytest
 from requests.exceptions import ConnectionError
@@ -79,10 +80,10 @@ class TestMprmWebsocket:
 
     @pytest.mark.usefixtures("mock_mprmwebsocket_websocketapp")
     def test__try_reconnect_with_detect(self, mocker):
-        spy_sleep = mocker.spy(time, "sleep")
-        spy_detect_gateway = mocker.spy(StubMprmWebsocket, "detect_gateway_in_lan")
-        self.mprm._ws = ConnectionError
-        self.mprm._local_ip = self.gateway["local_ip"]
-        self.mprm._try_reconnect(4)
-        spy_sleep.assert_called_once_with(1)
-        spy_detect_gateway.assert_called_once()
+        with patch("time.sleep") as sleep:
+            spy_detect_gateway = mocker.spy(StubMprmWebsocket, "detect_gateway_in_lan")
+            self.mprm._ws = ConnectionError
+            self.mprm._local_ip = self.gateway["local_ip"]
+            self.mprm._try_reconnect(4)
+            sleep.assert_called_once_with(1)
+            spy_detect_gateway.assert_called_once()


### PR DESCRIPTION
## Proposed change
<!--
  Please give us the big picture of your change.
-->
If you have a local connection that is a bit unreliable, you will see ConnectionErrors and with it re-establishing websocket every now and then. This MR adds a build retry of 5 with an increasing backoff time. In my case this avoided 100% of the ConnectionErrors and kept the websocket working. The cloud case is untouched as I suppose it is more robust by default.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [x] Changelog is updated.
