### PR TITLE
Allow local connections even if remote URL is not available

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: '22.3.0'
+    rev: '23.1.0'
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/isort
-    rev: '5.10.1'
+    rev: '5.12.0'
     hooks:
         - id: isort
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v4.1.0'
+    rev: 'v4.4.0'
     hooks:
         - id: end-of-file-fixer
         - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # devolo Home Control API
 
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/2Fake/devolo_home_control_api/Python%20package)](https://github.com/2Fake/devolo_home_control_api/actions?query=workflow%3A%22Python+package%22)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/2Fake/devolo_home_control_api/pythonpackage.yml?branch=master)](https://github.com/2Fake/devolo_home_control_api/actions?query=workflow%3A%22Python+package%22)
 [![PyPI - Downloads](https://img.shields.io/pypi/dd/devolo-home-control-api)](https://pypi.org/project/devolo-home-control-api/)
 [![Code Climate maintainability](https://img.shields.io/codeclimate/maintainability/2Fake/devolo_home_control_api)](https://codeclimate.com/github/2Fake/devolo_home_control_api)
 [![Coverage Status](https://coveralls.io/repos/github/2Fake/devolo_home_control_api/badge.svg?branch=master)](https://coveralls.io/github/2Fake/devolo_home_control_api?branch=master)

--- a/devolo_home_control_api/backend/mprm_rest.py
+++ b/devolo_home_control_api/backend/mprm_rest.py
@@ -21,6 +21,8 @@ class MprmRest(ABC):
     """
 
     def __init__(self) -> None:
+        logging.captureWarnings(True)
+
         self._logger = logging.getLogger(self.__class__.__name__)
         self._data_id = 0
         self._local_ip = ""
@@ -168,7 +170,7 @@ class MprmRest(ABC):
             self._logger.error("Gateway is offline.")
             self._logger.debug(sys.exc_info())
             self.gateway.update_state(False)
-            raise GatewayOfflineError("Gateway is offline.") from None
+            raise GatewayOfflineError from None
         if response["id"] != data["id"]:
             self._logger.error("Got an unexpected response after posting data.")
             self._logger.debug("Message had ID %s, response had ID %s.", data["id"], response["id"])

--- a/devolo_home_control_api/backend/mprm_websocket.py
+++ b/devolo_home_control_api/backend/mprm_websocket.py
@@ -66,7 +66,7 @@ class MprmWebsocket(MprmRest, ABC):
             time.sleep(0.1)
         if not self._connected:
             self._logger.debug("Websocket could not be established")
-            raise GatewayOfflineError("Websocket could not be established.")
+            raise GatewayOfflineError
 
     def websocket_connect(self) -> None:
         """
@@ -131,7 +131,7 @@ class MprmWebsocket(MprmRest, ABC):
             self._event_sequence += 1
         else:
             self._logger.warning(
-                "We missed a websocket message. Internal event_sequence is at %s. " "Event sequence by websocket is at %s",
+                "We missed a websocket message. Internal event_sequence is at %s. Event sequence by websocket is at %s",
                 self._event_sequence,
                 event_sequence,
             )

--- a/devolo_home_control_api/devices/gateway.py
+++ b/devolo_home_control_api/devices/gateway.py
@@ -30,7 +30,7 @@ class Gateway:  # pylint: disable=too-few-public-methods
         self.firmware_version = details.get("firmwareVersion")
 
         try:
-            self.full_url: str | None = self._mydevolo.get_full_url(self.id)
+            self.full_url: Optional[str] = self._mydevolo.get_full_url(self.id)
         except GatewayOfflineError:
             self.full_url = None
 

--- a/devolo_home_control_api/devices/gateway.py
+++ b/devolo_home_control_api/devices/gateway.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Dict, Optional
 
+from ..exceptions.gateway import GatewayOfflineError
 from ..mydevolo import Mydevolo
 
 
@@ -23,11 +24,15 @@ class Gateway:  # pylint: disable=too-few-public-methods
         self.id = details["gatewayId"]
         self.name = details.get("name")
         self.role = details.get("role")
-        self.full_url = self._mydevolo.get_full_url(self.id)
         self.local_user = self._mydevolo.uuid()
         self.local_passkey = details["localPasskey"]
         self.external_access = details.get("externalAccess")
         self.firmware_version = details.get("firmwareVersion")
+
+        try:
+            self.full_url: str | None = self._mydevolo.get_full_url(self.id)
+        except GatewayOfflineError:
+            self.full_url = None
 
         # Let's assume the gateway is connected remotely. Will be corrected as soon as a real connection is established.
         self.local_connection = False

--- a/devolo_home_control_api/exceptions/gateway.py
+++ b/devolo_home_control_api/exceptions/gateway.py
@@ -1,5 +1,9 @@
-"""Exceptions occuring when talking to the devolo Home Control central unit."""
+"""Exceptions occurring when talking to the devolo Home Control central unit."""
 
 
 class GatewayOfflineError(Exception):
     """The requested gateway is offline and cannot be used."""
+
+    def __init__(self) -> None:
+        """Initialize error."""
+        super().__init__("Gateway is offline.")

--- a/devolo_home_control_api/mydevolo.py
+++ b/devolo_home_control_api/mydevolo.py
@@ -30,7 +30,7 @@ class Mydevolo:
         return self._user
 
     @user.setter
-    def user(self, user: str):
+    def user(self, user: str) -> None:
         """Invalidate uuid and gateway IDs on user name change."""
         self._user = user
         self._uuid = ""
@@ -42,7 +42,7 @@ class Mydevolo:
         return self._password
 
     @password.setter
-    def password(self, password: str):
+    def password(self, password: str) -> None:
         """Invalidate uuid and gateway IDs on password change."""
         self._password = password
         self._uuid = ""
@@ -161,7 +161,7 @@ class Mydevolo:
             raise WrongUrlError(f"Wrong URL: {url}")
         if responds.status_code == requests.codes.service_unavailable:  # pylint: disable=no-member
             # mydevolo sends a 503, if the gateway is offline
-            self._logger.error("The requested gateway seems to be offline.")
-            raise GatewayOfflineError("Gateway offline.")
+            self._logger.warning("The requested gateway seems to be offline.")
+            raise GatewayOfflineError
 
         return responds.json()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.18.3] - 2023/03/14
+
+### Fixed
+
+- Allow local connections even if remote URL is not available
+
 ## [v0.18.2] - 2022/05/06
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ max-attributes = 15
 max-line-length = 127
 
 [tool.pylint.messages_control]
-disable = "C0330, C0326, R0801"
+disable = "R0801"
 good-names = "id,ip,ws"
 
 [tool.setuptools_scm]

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,29 +1,40 @@
+"""Test handling the gateway device."""
+from unittest.mock import patch
+
 import pytest
+
 from devolo_home_control_api.devices.gateway import Gateway
+from devolo_home_control_api.exceptions.gateway import GatewayOfflineError
+from devolo_home_control_api.mydevolo import Mydevolo
 
 
-@pytest.mark.usefixtures("mydevolo")
 @pytest.mark.usefixtures("mock_mydevolo__call")
 class TestGateway:
-    def test_update_state_known(self, mydevolo):
+    def test_offline_init(self, mydevolo: Mydevolo) -> None:
+        """Test, that a gateway can be setup while being offline."""
+        with patch("devolo_home_control_api.mydevolo.Mydevolo.get_full_url", side_effect=GatewayOfflineError):
+            gateway = Gateway(self.gateway.get("id"), mydevolo_instance=mydevolo)
+            assert not gateway.full_url
+
+    def test_update_state_known(self, mydevolo: Mydevolo) -> None:
+        """Test state change to knowingly being offline."""
         gateway = Gateway(self.gateway.get("id"), mydevolo_instance=mydevolo)
         gateway.update_state(False)
-
         assert not gateway.online
         assert not gateway.sync
 
-    def test_update_state_offline(self, mydevolo):
+    def test_update_state_offline(self, mydevolo: Mydevolo) -> None:
+        """Test state change to offline because of an update."""
         gateway = Gateway(self.gateway.get("id"), mydevolo_instance=mydevolo)
         gateway._update_state(status="devolo.hc_gateway.status.offline", state="devolo.hc_gateway.state.update")
-
         assert not gateway.online
         assert not gateway.sync
 
-    def test_update_state_unknown(self, mydevolo):
+    def test_update_state_unknown(self, mydevolo: Mydevolo) -> None:
+        """Test setting the state to the state mydevolo knows."""
         gateway = Gateway(self.gateway.get("id"), mydevolo_instance=mydevolo)
         gateway.online = False
         gateway.sync = False
         gateway.update_state()
-
         assert gateway.online
         assert gateway.sync

--- a/tests/test_mprm.py
+++ b/tests/test_mprm.py
@@ -1,64 +1,83 @@
+"""Test mPRM communication."""
 import pytest
 import zeroconf
+from requests import Session
 
 from devolo_home_control_api.exceptions.gateway import GatewayOfflineError
+from devolo_home_control_api.mydevolo import Mydevolo
 
 
 @pytest.mark.usefixtures("mprm_instance")
 class TestMprm:
     @pytest.mark.usefixtures("mock_mprm_get_local_session")
-    def test_create_connection_local(self, mprm_session):
+    def test_create_connection_local(self, mprm_session: Session) -> None:
+        """Test connecting locally."""
         self.mprm._session = mprm_session
         self.mprm._local_ip = self.gateway["local_ip"]
         self.mprm.create_connection()
 
     @pytest.mark.usefixtures("mock_mprmwebsocket_get_remote_session")
     @pytest.mark.usefixtures("mock_session_get")
-    def test_create_connection_remote(self, mprm_session, mydevolo):
+    def test_create_connection_remote(self, mprm_session: Session, mydevolo: Mydevolo) -> None:
+        """Test connecting remotely."""
         self.mprm._mydevolo = mydevolo
         self.mprm._session = mprm_session
         self.mprm.gateway.external_access = True
         self.mprm.create_connection()
 
-    def test_create_connection_invalid(self):
+    def test_create_connection_invalid(self) -> None:
+        """Test handling a connection error."""
         with pytest.raises(ConnectionError):
             self.mprm.gateway.external_access = False
             self.mprm.create_connection()
 
     @pytest.mark.usefixtures("mock_mprm_service_browser")
-    def test_detect_gateway_in_lan(self):
+    def test_detect_gateway_in_lan(self) -> None:
+        """Test detecting gateway in LAN."""
         self.mprm._local_ip = self.gateway["local_ip"]
         assert self.mprm.detect_gateway_in_lan() == self.gateway["local_ip"]
 
     @pytest.mark.usefixtures("mock_session_get")
     @pytest.mark.usefixtures("mock_response_json")
-    def test_get_local_session_valid(self, mprm_session):
+    def test_get_local_session_valid(self, mprm_session: Session) -> None:
+        """Test opening a session to the local mPRM."""
         self.mprm._session = mprm_session
         self.mprm._local_ip = self.gateway["local_ip"]
         assert self.mprm.get_local_session()
 
     @pytest.mark.usefixtures("mock_response_requests_ConnectTimeout")
-    def test_get_local_session_ConnectTimeout(self, mprm_session):
+    def test_get_local_session_ConnectTimeout(self, mprm_session: Session) -> None:
+        """Test handling a timeout occurring during opening session to the local mPRM."""
         self.mprm._session = mprm_session
         self.mprm._local_ip = self.gateway["local_ip"]
         with pytest.raises(GatewayOfflineError):
             self.mprm.get_local_session()
 
     @pytest.mark.usefixtures("mock_session_get_nok")
-    def test_get_local_session_connection_nok(self, mprm_session):
+    def test_get_local_session_connection_nok(self, mprm_session: Session) -> None:
+        """Test handling a connection reset occurring during opening session to the local mPRM."""
         self.mprm._session = mprm_session
         with pytest.raises(GatewayOfflineError):
             self.mprm.get_local_session()
 
+    def test_get_remote_session_connection_nok(self, mprm_session: Session) -> None:
+        """Test handling a missing full_url during opening session to the remote mPRM."""
+        self.mprm.gateway.full_url = None
+        self.mprm._session = mprm_session
+        with pytest.raises(GatewayOfflineError):
+            self.mprm.get_remote_session()
+
     @pytest.mark.usefixtures("mock_response_json_JSONDecodeError")
-    def test_get_remote_session_JSONDecodeError(self, mprm_session):
+    def test_get_remote_session_JSONDecodeError(self, mprm_session: Session) -> None:
+        """Test handling bad content received during opening session to the remote mPRM."""
         self.mprm._session = mprm_session
         with pytest.raises(GatewayOfflineError):
             self.mprm.get_remote_session()
 
     @pytest.mark.usefixtures("mock_mprm_service_browser")
     @pytest.mark.usefixtures("mock_mprm__try_local_connection")
-    def test__on_service_state_change(self):
+    def test__on_service_state_change(self) -> None:
+        """Test handling a zeroconf state change."""
         zc = zeroconf.Zeroconf()
         service_type = "_http._tcp.local."
         self.mprm._on_service_state_change(zc, service_type, service_type, zeroconf.ServiceStateChange.Added)
@@ -66,7 +85,8 @@ class TestMprm:
 
     @pytest.mark.usefixtures("mock_socket_inet_ntoa")
     @pytest.mark.usefixtures("mock_response_valid")
-    def test__try_local_connection_success(self, mprm_session):
+    def test__try_local_connection_success(self, mprm_session: Session) -> None:
+        """Test connecting locally."""
         self.mprm._session = mprm_session
         self.mprm._try_local_connection([self.gateway["local_ip"]])
         assert self.mprm._local_ip == self.gateway["local_ip"]


### PR DESCRIPTION
## Proposed change
It might happen, that the local connection works just fine, but a new connection cannot be established, because the remote connection is not working. This MR adds a possibility to ignore the remote connection, if local works.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [x] Changelog is updated.
