### PR TITLE
Use lru_cache for getting the UUID

### DIFF
--- a/tests/fixtures/mydevolo.py
+++ b/tests/fixtures/mydevolo.py
@@ -1,15 +1,19 @@
+"""Fixtures used for mydevolo testing."""
+from collections.abc import Generator
+from unittest.mock import patch
+
 import pytest
+
 from devolo_home_control_api.mydevolo import Mydevolo, WrongCredentialsError, WrongUrlError
 
 from ..mocks.mock_mydevolo import MockMydevolo
 
 
 @pytest.fixture()
-def mydevolo(request):
+def mydevolo(request: pytest.FixtureRequest) -> Generator[Mydevolo, None, None]:
     """Create real mydevolo object with static test data."""
-    mydevolo_instance = Mydevolo()
-    mydevolo_instance._uuid = request.cls.user.get("uuid")
-    yield mydevolo_instance
+    with patch("devolo_home_control_api.mydevolo.Mydevolo.uuid", return_value=request.cls.user.get("uuid")):
+        yield Mydevolo()
 
 
 @pytest.fixture()
@@ -26,9 +30,10 @@ def mock_mydevolo__call_raise_WrongUrlError(mocker):
 
 
 @pytest.fixture()
-def mock_mydevolo_uuid_raise_WrongCredentialsError(mocker):
+def mock_mydevolo_uuid_raise_WrongCredentialsError(mydevolo: Mydevolo) -> Generator[Mydevolo, None, None]:
     """Respond with WrongCredentialsError on calls to the mydevolo API."""
-    mocker.patch("devolo_home_control_api.mydevolo.Mydevolo.uuid", side_effect=WrongCredentialsError)
+    with patch("devolo_home_control_api.mydevolo.Mydevolo.uuid", side_effect=WrongCredentialsError):
+        yield mydevolo
 
 
 @pytest.fixture()

--- a/tests/fixtures/mydevolo.py
+++ b/tests/fixtures/mydevolo.py
@@ -1,8 +1,9 @@
 """Fixtures used for mydevolo testing."""
-from collections.abc import Generator
+from typing import Generator
 from unittest.mock import patch
 
 import pytest
+from pytest_mock import MockerFixture
 
 from devolo_home_control_api.mydevolo import Mydevolo, WrongCredentialsError, WrongUrlError
 
@@ -17,14 +18,14 @@ def mydevolo(request: pytest.FixtureRequest) -> Generator[Mydevolo, None, None]:
 
 
 @pytest.fixture()
-def mock_mydevolo__call(mocker, request):
+def mock_mydevolo__call(mocker: MockerFixture, request: pytest.FixtureRequest) -> None:
     """Mock calls to the mydevolo API."""
     mock_mydevolo = MockMydevolo(request)
     mocker.patch("devolo_home_control_api.mydevolo.Mydevolo._call", side_effect=mock_mydevolo._call)
 
 
 @pytest.fixture()
-def mock_mydevolo__call_raise_WrongUrlError(mocker):
+def mock_mydevolo__call_raise_WrongUrlError(mocker: MockerFixture) -> None:
     """Respond with WrongUrlError on calls to the mydevolo API."""
     mocker.patch("devolo_home_control_api.mydevolo.Mydevolo._call", side_effect=WrongUrlError)
 
@@ -37,6 +38,6 @@ def mock_mydevolo_uuid_raise_WrongCredentialsError(mydevolo: Mydevolo) -> Genera
 
 
 @pytest.fixture()
-def mock_get_zwave_products(mocker):
+def mock_get_zwave_products(mocker: MockerFixture) -> None:
     """Mock Z-Wave product information call to speed up tests."""
     mocker.patch("devolo_home_control_api.mydevolo.Mydevolo.get_zwave_products", return_value={})

--- a/tests/test_mydevolo.py
+++ b/tests/test_mydevolo.py
@@ -1,98 +1,119 @@
+"""Test mydevolo."""
 import pytest
+
 from devolo_home_control_api.mydevolo import GatewayOfflineError, Mydevolo, WrongCredentialsError, WrongUrlError
 
 
 class TestMydevolo:
-    def test_credentials_valid(self, mydevolo):
+    def test_credentials_valid(self, mydevolo: Mydevolo) -> None:
+        """Test credential validation."""
         assert mydevolo.credentials_valid()
 
     @pytest.mark.usefixtures("mock_mydevolo_uuid_raise_WrongCredentialsError")
-    def test_credentials_invalid(self, mydevolo):
+    def test_credentials_invalid(self, mydevolo: Mydevolo) -> None:
+        """Test credential validation."""
         assert not mydevolo.credentials_valid()
 
     @pytest.mark.usefixtures("mock_mydevolo__call")
-    def test_gateway_ids(self, mydevolo):
+    def test_gateway_ids(self, mydevolo: Mydevolo) -> None:
+        """Test getting gateway serial numbers."""
         assert mydevolo.get_gateway_ids() == [self.gateway["id"]]
 
     @pytest.mark.usefixtures("mock_mydevolo__call")
-    def test_gateway_ids_empty(self, mydevolo):
+    def test_gateway_ids_empty(self, mydevolo: Mydevolo) -> None:
+        """Test raising on empty gateway list."""
         with pytest.raises(IndexError):
             mydevolo.get_gateway_ids()
 
     @pytest.mark.usefixtures("mock_mydevolo__call")
-    def test_get_full_url(self, mydevolo):
+    def test_get_full_url(self, mydevolo: Mydevolo) -> None:
+        """Test getting the remote mPRM URL."""
         full_url = mydevolo.get_full_url(self.gateway["id"])
         assert full_url == self.gateway["full_url"]
 
     @pytest.mark.usefixtures("mock_mydevolo__call")
-    def test_get_gateway(self, mydevolo):
+    def test_get_gateway(self, mydevolo: Mydevolo) -> None:
+        """Test getting gateway details."""
         details = mydevolo.get_gateway(self.gateway["id"])
         assert details.get("gatewayId") == self.gateway["id"]
 
     @pytest.mark.usefixtures("mock_mydevolo__call_raise_WrongUrlError")
-    def test_get_gateway_invalid(self, mydevolo):
+    def test_get_gateway_invalid(self, mydevolo: Mydevolo) -> None:
+        """Test raising on wrong gateway serial number."""
         with pytest.raises(WrongUrlError):
             mydevolo.get_gateway(self.gateway["id"])
 
     @pytest.mark.usefixtures("mock_mydevolo__call")
-    def test_get_zwave_products(self, mydevolo):
+    def test_get_zwave_products(self, mydevolo: Mydevolo) -> None:
+        """Test getting Z-Wave product information."""
         device_info = mydevolo.get_zwave_products(manufacturer="0x0060", product_type="0x0001", product="0x000")
         assert device_info.get("name") == "Everspring PIR Sensor SP814"
 
     @pytest.mark.usefixtures("mock_mydevolo__call_raise_WrongUrlError")
-    def test_get_zwave_products_invalid(self, mydevolo):
+    def test_get_zwave_products_invalid(self, mydevolo: Mydevolo) -> None:
+        """Test handling unknown Z-wave products."""
         device_info = mydevolo.get_zwave_products(manufacturer="0x0070", product_type="0x0001", product="0x000")
         assert device_info.get("name") == "Unknown"
 
     @pytest.mark.usefixtures("mock_mydevolo__call")
     @pytest.mark.parametrize("result", [True, False])
-    def test_maintenance(self, mydevolo, result):
+    def test_maintenance(self, mydevolo: Mydevolo, result: bool) -> None:
+        """Test checking for maintenance mode."""
         assert mydevolo.maintenance() == result
 
-    def test_set_password(self, mydevolo):
+    def test_set_password(self, mydevolo: Mydevolo) -> None:
+        """Test setting a new password."""
         mydevolo._gateway_ids = [self.gateway["id"]]
         mydevolo.password = self.user["password"]
-
-        assert mydevolo._uuid == ""
+        assert mydevolo.uuid.cache_clear.call_count == 1
         assert mydevolo._gateway_ids == []
 
-    def test_set_user(self, mydevolo):
+    def test_set_user(self, mydevolo: Mydevolo) -> None:
+        """Test setting a new username."""
         mydevolo._gateway_ids = [self.gateway["id"]]
         mydevolo.user = self.user["username"]
-
-        assert mydevolo._uuid == ""
+        assert mydevolo.uuid.cache_clear.call_count == 1
         assert mydevolo._gateway_ids == []
 
-    def test_get_user(self, mydevolo):
+    def test_get_user(self, mydevolo: Mydevolo) -> None:
+        """Test getting the username."""
         mydevolo.user = self.user["username"]
         assert mydevolo.user == self.user["username"]
 
-    def test_get_password(self, mydevolo):
+    def test_get_password(self, mydevolo: Mydevolo) -> None:
+        """Test getting the password."""
         mydevolo.password = self.user["password"]
         assert mydevolo.password == self.user["password"]
 
     @pytest.mark.usefixtures("mock_mydevolo__call")
-    def test_uuid(self, mydevolo):
-        mydevolo._uuid = ""
+    def test_uuid(self) -> None:
+        """Test getting the uuid."""
+        mydevolo = Mydevolo()
         assert mydevolo.uuid() == self.user["uuid"]
+        assert mydevolo.uuid() == self.user["uuid"]
+        assert mydevolo.uuid.cache_info().hits == 1
 
     @pytest.mark.usefixtures("mock_response_wrong_credentials_error")
-    def test_call_WrongCredentialsError(self):
+    def test_call_WrongCredentialsError(self) -> None:
+        """Test raising on wrong credentials."""
         mydevolo = Mydevolo()
         with pytest.raises(WrongCredentialsError):
             mydevolo._call("test")
 
     @pytest.mark.usefixtures("mock_response_wrong_url_error")
-    def test_call_WrongUrlError(self):
+    def test_call_WrongUrlError(self) -> None:
+        """Test raising on wrong URL."""
         mydevolo = Mydevolo()
         with pytest.raises(WrongUrlError):
             mydevolo._call("test")
 
     @pytest.mark.usefixtures("mock_response_gateway_offline")
-    def test_call_GatewayOfflineError(self, mydevolo):
+    def test_call_GatewayOfflineError(self, mydevolo: Mydevolo) -> None:
+        """Test raising on offline gateway."""
         with pytest.raises(GatewayOfflineError):
             mydevolo._call("test")
 
     @pytest.mark.usefixtures("mock_response_valid")
-    def test_call_valid(self, mydevolo):
+    def test_call_valid(self, mydevolo: Mydevolo) -> None:
+        """Test valid calls."""
         assert mydevolo._call("test").get("response") == "response"


### PR DESCRIPTION
## Proposed change

Use lru_cache for getting the UUID instead of a private property.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [ ] Changelog is updated.
